### PR TITLE
Add `getavailablerules`, `getavailableorders`, `getavailablepoints`

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ Lebedev determined 65 quadrature rules ranging from order 3 up to order 131, inc
 (hence only odd-numbered orders are known), however, this package only provides a subset of them.
 Use the function `isavailable(n::Integer)` to know if the quadrature rule for a given order `n` is
 available and the function `availablerules()` to print out all available orders and corresponding
-number of points.
+number of points. If you need to access the list of available orders or points, use
+`getavailablerules()` and `getavailablepoints()`, which return lists sorted in ascending order.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ Lebedev determined 65 quadrature rules ranging from order 3 up to order 131, inc
 Use the function `isavailable(n::Integer)` to know if the quadrature rule for a given order `n` is
 available and the function `availablerules()` to print out all available orders and corresponding
 number of points. If you need to access the list of available orders or points, use
-`getavailablerules()` and `getavailablepoints()`, which return lists sorted in ascending order.
+`getavailablerules()` (returns a order⇒points dictionary), `getavailableorders()`, and
+`getavailablepoints()`; the latters return lists of integers sorted in ascending order.
 
 ## Examples
 

--- a/src/Lebedev.jl
+++ b/src/Lebedev.jl
@@ -44,7 +44,9 @@ include("sphere_lebedev_rule.jl")
 export lebedev_by_points
 export lebedev_by_order
 export isavailable
+export availablerules
 export getavailablerules
 export getavailableorders
+export getavailablepoints
 
 end

--- a/src/Lebedev.jl
+++ b/src/Lebedev.jl
@@ -44,6 +44,7 @@ include("sphere_lebedev_rule.jl")
 export lebedev_by_points
 export lebedev_by_order
 export isavailable
-export availablerules
+export getavailablerules
+export getavailableorders
 
 end

--- a/src/sphere_lebedev_rule.jl
+++ b/src/sphere_lebedev_rule.jl
@@ -4656,6 +4656,15 @@ getavailablepoints() = values(rules) |> collect |> sort
 
 
 """
+    getavailablerules()
+
+Return a dictionary associating each order to its number of points.
+See also `getavailableorders`[@ref] and `getavailablepoints`[@ref].
+"""
+getavailablerules() = copy(rules)  # Return a copy
+
+
+"""
     lebedev_by_order(n::Integer)
 
 Compute the Lebedev angular grid corresponding to order number `n`.

--- a/src/sphere_lebedev_rule.jl
+++ b/src/sphere_lebedev_rule.jl
@@ -4624,7 +4624,9 @@ end
 """
     availablerules()
 
-Print a table showing the available Lebedev quadrature rules.
+Print a table showing the available Lebedev quadrature rules. If you need
+to programmatically access the rules, use `getavailableorders`[@ref] and
+`getavailablepoints`[@ref].
 """
 function availablerules()
     println("order | points")
@@ -4633,6 +4635,24 @@ function availablerules()
         @printf("%5i | %6i\n",rule.first,rule.second)
     end
 end
+
+
+"""
+    getavailableorders()
+
+Return a list of the available orders, in ascending order. See also
+`getavailablepoints`[@ref].
+"""
+getavailableorders() = keys(rules) |> collect |> sort
+
+
+"""
+    getavailablepoints()
+
+Return a list of the available number of points, in ascending order.
+See also `getavailableorders`[@ref].
+"""
+getavailablepoints() = values(rules) |> collect |> sort
 
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -237,18 +237,30 @@ end
 
 
 @testset "Query functions" begin
-    orders = Lebedev.getavailableorders()
-
     ispositive(x) = x > 0
     
+    orders = Lebedev.getavailableorders()
+    @test !isnothing(orders)
     # Test that the list has some elements in it
     @test !isempty(orders)
     # Test that the list is sorted in ascending order
     @test all(ispositive, orders[2:end] .- orders[1:end-1])
     
     points = Lebedev.getavailablepoints()
+    @test !isnothing(points)
     # Ditto
     @test !isempty(points)
     # Ditto
     @test all(ispositive, points[2:end] .- points[1:end-1])
+
+    rules = Lebedev.getavailablerules()
+    @test !isnothing(rules)
+    @test !isempty(rules)
+
+    # Try to modify the dictionary returned by `getavailablerules`
+    rules[orders[1]] = points[1] + 1
+
+    # Check that the list of rules has not changed
+    rules = Lebedev.getavailablerules()
+    @test rules[orders[1]] == points[1]
  end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -234,3 +234,21 @@ for order in keys(Lebedev.rules)
     end
     global last_order = order
 end
+
+
+@testset "Query functions" begin
+    orders = Lebedev.getavailableorders()
+
+    ispositive(x) = x > 0
+    
+    # Test that the list has some elements in it
+    @test !isempty(orders)
+    # Test that the list is sorted in ascending order
+    @test all(ispositive, orders[2:end] .- orders[1:end-1])
+    
+    points = Lebedev.getavailablepoints()
+    # Ditto
+    @test !isempty(points)
+    # Ditto
+    @test all(ispositive, points[2:end] .- points[1:end-1])
+ end


### PR DESCRIPTION
The current API lacks a way to programmatically query for the list of supported orders/points, as `availablerules` only prints them to the terminal but does not *return* them. This means that quadrature codes cannot easily implement algorithms that search for the optimal order to be used (`isavailable` is not sufficient because there is no way to get an upper bound for the order).

This PR adds three new functions:

-   `getavailablerules` returns a copy of the `rules` dictionary;
-   `getavailableorders` returns a sorted list of supported orders;
-   `getavailablepoints` returns a sorted list of the number of points associated with each order.

Tests have been added for each function, and the README has been updated accordingly. It does not alter any existing function, so these changes should be fully backward-compatible.